### PR TITLE
Fix webchat not displaying user addresses

### DIFF
--- a/modules/haproxy/templates/haproxy.cfg.erb
+++ b/modules/haproxy/templates/haproxy.cfg.erb
@@ -128,7 +128,7 @@ backend irc
     timeout server 5m
     balance roundrobin
     option httpchk
-    server hive 130.159.141.66:80 weight 1 maxconn 10000
+    server hive 130.159.141.66:9090 weight 1 maxconn 10000
     
 # HTTP Reverse Proxy
 listen  http 0.0.0.0:80


### PR DESCRIPTION
This should fix all users being shown as connecting from 127.0.0.1
